### PR TITLE
NOISSUE - Return correct ChannelsPage in ThingChannels 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@absmach/magistrala-sdk",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Official Magistrala sdk",
   "main": "./dist/sdk.js",
   "module": "./dist/sdk.mjs",

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -156,8 +156,14 @@ export default class Channels {
         const errorRes = await response.json()
         throw this.channelError.HandleError(errorRes.message, response.status)
       }
-      const channels: ChannelsPage = await response.json()
-      return channels
+      const channels = await response.json()
+      const channelsPage: ChannelsPage = {
+        channels: channels.groups,
+        total: channels.total,
+        limit: channels.limit,
+        offset: channels.offset
+      }
+      return channelsPage
     } catch (error) {
       throw error
     }


### PR DESCRIPTION
### What does this do?
Fixes a bug where in the thingChannels page the payload is `channelsPage.channels` instead of `channelsPage.Groups`

### Which issue(s) does this PR fix/relate to?
There is no such issue

### List any changes that modify/break current functionality
The channelsPage returned uses `channels` instead of `groups`

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
No.

### Notes
N/A