### PR TITLE
NOISSUE - Update ChannelsPage Interface

### DIFF
--- a/.changeset/spicy-eagles-behave.md
+++ b/.changeset/spicy-eagles-behave.md
@@ -1,0 +1,5 @@
+---
+"@absmach/magistrala-sdk": patch
+---
+
+Update channelsPage interface

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@absmach/magistrala-sdk",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@absmach/magistrala-sdk",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@changesets/cli": "^2.27.6",

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -156,12 +156,7 @@ export default class Channels {
         const errorRes = await response.json()
         throw this.channelError.HandleError(errorRes.message, response.status)
       }
-      const channels = await response.json()
-      const channelsPage: ChannelsPage = {
-        channels: channels.channels,
-        total: channels.total,
-        offset: channels.offset
-      }
+      const channelsPage: ChannelsPage = await response.json()
       return channelsPage
     } catch (error) {
       throw error
@@ -203,12 +198,7 @@ export default class Channels {
         const errorRes = await response.json()
         throw this.channelError.HandleError(errorRes.message, response.status)
       }
-      const channels = await response.json()
-      const channelsPage: ChannelsPage = {
-        channels: channels.channels,
-        total: channels.total,
-        offset: channels.offset
-      }
+      const channelsPage: ChannelsPage = await response.json()
       return channelsPage
     } catch (error) {
       throw error

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -204,7 +204,6 @@ export default class Channels {
         throw this.channelError.HandleError(errorRes.message, response.status)
       }
       const channels = await response.json()
-      console.log('channels', channels)
       const channelsPage: ChannelsPage = {
         channels: channels.channels,
         total: channels.total,

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -158,9 +158,8 @@ export default class Channels {
       }
       const channels = await response.json()
       const channelsPage: ChannelsPage = {
-        channels: channels.groups,
+        channels: channels.channels,
         total: channels.total,
-        limit: channels.limit,
         offset: channels.offset
       }
       return channelsPage
@@ -205,10 +204,10 @@ export default class Channels {
         throw this.channelError.HandleError(errorRes.message, response.status)
       }
       const channels = await response.json()
+      console.log('channels', channels)
       const channelsPage: ChannelsPage = {
-        channels: channels.groups,
+        channels: channels.channels,
         total: channels.total,
-        limit: channels.limit,
         offset: channels.offset
       }
       return channelsPage

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -100,7 +100,6 @@ export interface ChannelsPage {
   channels: Channel[]
   total: number
   offset: number
-  limit: number
 }
 
 export interface Login {

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -463,12 +463,7 @@ export default class Groups {
         const errorRes = await response.json()
         throw this.groupError.HandleError(errorRes.message, response.status)
       }
-      const channels = await response.json()
-      const channelsPage: ChannelsPage = {
-        channels: channels.channels,
-        total: channels.total,
-        offset: channels.offset
-      }
+      const channelsPage: ChannelsPage = await response.json()
       return channelsPage
     } catch (error) {
       throw error

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -465,9 +465,8 @@ export default class Groups {
       }
       const channels = await response.json()
       const channelsPage: ChannelsPage = {
-        channels: channels.groups,
+        channels: channels.channels,
         total: channels.total,
-        limit: channels.limit,
         offset: channels.offset
       }
       return channelsPage

--- a/src/users.ts
+++ b/src/users.ts
@@ -739,12 +739,7 @@ export default class Users {
         const errorRes = await response.json()
         throw this.userError.HandleError(errorRes.message, response.status)
       }
-      const channels = await response.json()
-      const channelsPage: ChannelsPage = {
-        channels: channels.channels,
-        total: channels.total,
-        offset: channels.offset
-      }
+      const channelsPage: ChannelsPage = await response.json()
       return channelsPage
     } catch (error) {
       throw error

--- a/src/users.ts
+++ b/src/users.ts
@@ -741,9 +741,8 @@ export default class Users {
       }
       const channels = await response.json()
       const channelsPage: ChannelsPage = {
-        channels: channels.groups,
+        channels: channels.channels,
         total: channels.total,
-        limit: channels.limit,
         offset: channels.offset
       }
       return channelsPage

--- a/tests/channels.test.ts
+++ b/tests/channels.test.ts
@@ -60,10 +60,9 @@ describe('Channels', () => {
     limit: 10
   }
   const channelsPage = {
-    groups: [channel],
+    channels: [channel],
     total: 1,
-    offset: 0,
-    limit: 10
+    offset: 0
   }
   const channelId = '290b0f49-7a57-4b8c-9e4e-fbf17c6ab7d9'
   const thingId = 'bb7edb32-2eac-4aad-aebe-ed96fe073879'
@@ -204,7 +203,6 @@ describe('Channels', () => {
     expect(response).toEqual({
       offset: 0,
       total: 1,
-      limit: 10,
       channels: [channel]
     })
   })
@@ -216,7 +214,6 @@ describe('Channels', () => {
     expect(response).toEqual({
       offset: 0,
       total: 1,
-      limit: 10,
       channels: [channel]
     })
   })

--- a/tests/channels.test.ts
+++ b/tests/channels.test.ts
@@ -200,22 +200,14 @@ describe('Channels', () => {
     fetchMock.mockResponseOnce(JSON.stringify(channelsPage))
 
     const response = await sdk.channels.Channels(queryParams, token)
-    expect(response).toEqual({
-      offset: 0,
-      total: 1,
-      channels: [channel]
-    })
+    expect(response).toEqual(channelsPage)
   })
 
   test('ChannelsByThing should retrieve things a channel is connected to and return success', async () => {
     fetchMock.mockResponseOnce(JSON.stringify(channelsPage))
 
     const response = await sdk.channels.ChannelsByThing(channelId, queryParams, token)
-    expect(response).toEqual({
-      offset: 0,
-      total: 1,
-      channels: [channel]
-    })
+    expect(response).toEqual(channelsPage)
   })
 
   test('ChannelPermissions should retrieve channel permissions and return success', async () => {

--- a/tests/groups.test.ts
+++ b/tests/groups.test.ts
@@ -74,10 +74,9 @@ describe('Groups', () => {
   }
 
   const channelsPage = {
-    groups: [channel],
+    channels: [channel],
     total: 1,
-    offset: 0,
-    limit: 10
+    offset: 0
   }
 
   beforeEach(() => {
@@ -180,8 +179,7 @@ describe('Groups', () => {
     expect(response).toEqual({
       channels: [channel],
       total: 1,
-      offset: 0,
-      limit: 10
+      offset: 0
     })
   })
 

--- a/tests/groups.test.ts
+++ b/tests/groups.test.ts
@@ -176,11 +176,7 @@ describe('Groups', () => {
     fetchMock.mockResponseOnce(JSON.stringify(channelsPage))
 
     const response = await sdk.groups.ListGroupChannels(groupId, queryParams, token)
-    expect(response).toEqual({
-      channels: [channel],
-      total: 1,
-      offset: 0
-    })
+    expect(response).toEqual(channelsPage)
   })
 
   test('parents should get all of a groups parents and return success', async () => {

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -214,11 +214,7 @@ describe('Users', () => {
     fetchMock.mockResponseOnce(JSON.stringify(channelsPage))
 
     const response = await sdk.users.ListUserChannels(userId, queryParams, token)
-    expect(response).toEqual({
-      channels: [channel],
-      total: 1,
-      offset: 0
-    })
+    expect(response).toEqual(channelsPage)
   })
 
   test('reset user password request should send a password reset request and return success', async () => {

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -89,9 +89,8 @@ describe('Users', () => {
   }
 
   const channelsPage = {
-    groups: [channel],
+    channels: [channel],
     total: 1,
-    limit: 10,
     offset: 0
   }
 
@@ -218,7 +217,6 @@ describe('Users', () => {
     expect(response).toEqual({
       channels: [channel],
       total: 1,
-      limit: 10,
       offset: 0
     })
   })


### PR DESCRIPTION
### What does this do?
This PR updates the channelsPage interface to match the backend with `channels.channels` instead of `channels.groups`
### Which issue(s) does this PR fix/relate to?
N/A

### List any changes that modify/break current functionality

### Have you included tests for your changes?
Yes
### Did you document any new/modified functionality?
No
### Notes
