### PR TITLE
NOISSUE - Add save_json output type to Rules Engine SDK

### DIFF
--- a/.changeset/add-save-json-output-type.md
+++ b/.changeset/add-save-json-output-type.md
@@ -1,0 +1,5 @@
+---
+"@absmach/magistrala-sdk": minor
+---
+
+Add `SAVE_JSON` output type for saving JSON-structured messages to the internal database via the Rules Engine, alongside the existing `SAVE_SENML` output.

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -530,6 +530,7 @@ export interface MembersPage {
 export enum OutputType {
   CHANNELS = "channels",
   SAVE_SENML = "save_senml",
+  SAVE_JSON = "save_json",
   ALARMS = "alarms",
   EMAIL = "email",
   SAVE_REMOTE_PG = "save_remote_pg",


### PR DESCRIPTION
## Summary
- Adds `SAVE_JSON = "save_json"` to the `OutputType` enum, alongside the existing `SAVE_SENML`.
- No new `Output`-extending interface needed — like `SAVE_SENML`, this output type carries no extra fields beyond the base `Output { type }` shape.
- Enables the Rules Engine's "Internal DB" output to save raw JSON-structured messages (not just SenML), which the Magistrala UI's Message Views / JSON viewer feature can then display.

## Test plan
- [x] `npm run build` passes (tsup build + type generation)
- [ ] Consumed from magistrala-ui once published, to wire up a new "Internal DB (JSON)" rule output node